### PR TITLE
Add [] overloading + Proxy class to mailbox lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,15 @@ Mailbox.watchdog();
 ```
 
 ### Access/Update data
+
 ```cpp
+// Update a mailbox entry (write)
+Mailbox[mbx_index::EXAMPLE_INT_MSG] = return_value;
 
-Mailbox.update( return_value, static_cast<int>(mbx_index::EXAMPLE_INT_MSG ) );
-temp_data = Mailbox.access( mbx_index::EXAMPLE_RX_MSG, temp_flag );
+// Access a mailbox entry (read)
+flag_type temp_flag;
+temp_data = Mailbox[mbx_index::EXAMPLE_RX_MSG].access_with_flag(temp_flag);
 
+// If you don't need the flag, you can read directly:
+data_union simple_data = Mailbox[mbx_index::EXAMPLE_RX_MSG];
 ```

--- a/mailbox.hpp
+++ b/mailbox.hpp
@@ -97,10 +97,36 @@ enum mailbox_error_types               /* error bit array defines   */
 --------------------------------------------------------------------*/
 
 /*--------------------------------------------------------------------
-                               CLASSES
+                             PROXY CLASSES
 --------------------------------------------------------------------*/
 namespace core {
+/*--------------------------------------------------
+forward declaration of mailbox class
+--------------------------------------------------*/
+template<int M>
+class mailbox;
 
+/*--------------------------------------------------
+Proxy class to enable operator[] read/write syntax
+--------------------------------------------------*/
+template<int M>
+class mailbox_accessor
+    {
+    public:
+        mailbox_accessor(mailbox<M>& mbx, mbx_index idx);                                  /* constructor                  */
+        mailbox_accessor& operator=(const data_union& data);                               /* assignment operator          */
+        operator data_union() const;                                                       /* type conversion operator     */
+        data_union access_with_flag(flag_type& current_flag, bool clear_flag = true);      /* access with flag             */
+
+    private:
+        mailbox<M>& p_mailbox;      /* reference to parent mailbox */
+        const mbx_index p_index;    /* index for this accessor     */
+    };
+
+
+/*--------------------------------------------------------------------
+                            MAILBOX CLASSE
+--------------------------------------------------------------------*/
 template<int M>
 class mailbox
     {
@@ -114,6 +140,10 @@ class mailbox
 
         data_union access( mbx_index global_mbx_indx, flag_type& current_flag, bool clear_flag = true ); /* mailbox data access */
         bool update( data_union d, int global_mbx_indx, bool user_mode = true );                         /* mailbox data update */
+
+        
+        mailbox_accessor<M> operator[](mbx_index index);      /* overload [] 
+                                                                  operator      */
 
     private:
         std::array<mailbox_type, M>& p_mailbox_ref;    /* global mailbox map reference  */

--- a/mailbox.hpp
+++ b/mailbox.hpp
@@ -140,7 +140,6 @@ class mailbox
 
         data_union access( mbx_index global_mbx_indx, flag_type& current_flag, bool clear_flag = true ); /* mailbox data access */
         bool update( data_union d, int global_mbx_indx, bool user_mode = true );                         /* mailbox data update */
-
         
         mailbox_accessor<M> operator[](mbx_index index);      /* overload [] 
                                                                   operator      */

--- a/mailbox.tpp
+++ b/mailbox.tpp
@@ -1325,11 +1325,9 @@ core::mailbox_accessor<M> core::mailbox<M>::operator[](mbx_index index)
 
 /*
 more thoughts
-
 1) table should be global accross units, which means terms like source and destination, make sense? no dual communication -- YES! v1.1 update 
 3) add back engine var to mailbox map, each "engine" will handle its on tx/rx queue, remove lora pack/unpack junk.
    interface format will have common *._add_tx_queue(), *._rx_runtime(&global_rx_queue), *.tx_runtime()?  		 		  -- Yes v1.1 update
 4) change queues to std::maps OR std::array. this will allow us to mark data as "to send" and avoid duplicate acks etc.   -- Yes v1.1 update
 5) update access/update using mailbox_idx + change to standard enums to avoid multiple casting							  -- Yes v1.1 update
-6) CORE-46: overload [] for access/set function																			  -- Yes v1.1 update
 */

--- a/mailbox.tpp
+++ b/mailbox.tpp
@@ -1234,6 +1234,95 @@ return p_current_round;
 } /* core::mailbox::update_round() */
 
 
+/*********************************************************************
+*
+*   PROCEDURE NAME:
+*       core::mailbox_accessor<M>::mailbox_accessor
+*
+*   DESCRIPTION:
+*       constructor for the accessor proxy class
+*
+*   NOTE:
+*
+*********************************************************************/
+template<int M>
+core::mailbox_accessor<M>::mailbox_accessor(core::mailbox<M>& mbx, mbx_index idx)
+    : p_mailbox(mbx), p_index(idx)
+{
+    // Left blank intentionally
+} /* core::mailbox_accessor<M>::mailbox_accessor */
+
+/*********************************************************************
+*
+*   PROCEDURE NAME:
+*       core::mailbox_accessor<M>::operator=
+*
+*   DESCRIPTION:
+*       assignment operator overload for the proxy class
+*
+*   NOTE:
+*
+*********************************************************************/
+template<int M>
+core::mailbox_accessor<M>& core::mailbox_accessor<M>::operator=(const data_union& data)
+{
+    p_mailbox.update(data, static_cast<int>(p_index), true);
+    return *this;
+} /* core::mailbox_accessor<M>::operator= */
+
+/*********************************************************************
+*
+*   PROCEDURE NAME:
+*       core::mailbox_accessor<M>::operator data_union
+*
+*   DESCRIPTION:
+*       type conversion operator for the proxy class
+*
+*   NOTE:
+*
+*********************************************************************/
+template<int M>
+core::mailbox_accessor<M>::operator data_union() const
+{
+    flag_type dummy_flag;
+    return p_mailbox.access(p_index, dummy_flag, true);
+} /* core::mailbox_accessor<M>::operator data_union() */
+
+/*********************************************************************
+*
+*   PROCEDURE NAME:
+*       core::mailbox_accessor<M>::access_with_flag
+*
+*   DESCRIPTION:
+*       allows access to the underlying flag
+*
+*   NOTE:
+*
+*********************************************************************/
+template<int M>
+data_union core::mailbox_accessor<M>::access_with_flag(flag_type& current_flag, bool clear_flag)
+{
+    return p_mailbox.access(p_index, current_flag, clear_flag);
+} /* core::mailbox_accessor<M>::access_with_flag() */
+
+/*********************************************************************
+*
+*   PROCEDURE NAME:
+*       core::mailbox<M>::operator[]
+*
+*   DESCRIPTION:
+*       [] operator overload, returns a proxy object
+*
+*   NOTE:
+*
+*********************************************************************/
+template<int M>
+core::mailbox_accessor<M> core::mailbox<M>::operator[](mbx_index index)
+{
+    return mailbox_accessor<M>(*this, index);
+} /* core::mailbox<M>::operator[] */
+
+
 /*
 more thoughts
 

--- a/test/mailbox_test.cpp
+++ b/test/mailbox_test.cpp
@@ -143,7 +143,7 @@ while( rx_itr != rx_test_cases.end() )
     /*------------------------------------------------------
     Get test command
     ------------------------------------------------------*/
-    temp_data = Mailbox[mbx_index::TEST_TX_FROM_RPI_MSG].access_with_flag(temp_flag);
+    temp_data = Mailbox[mbx_index::TEST_TX_FROM_RPI_MSG];
 
     /*------------------------------------------------------
     Find command in rx_test_cases map

--- a/test/mailbox_test.cpp
+++ b/test/mailbox_test.cpp
@@ -113,7 +113,7 @@ while( tx_itr != tx_test_cases.end() )
     /*------------------------------------------------------
     Read test variable
     ------------------------------------------------------*/
-    temp_data = Mailbox.access( (tx_itr->second).first, temp_flag );
+    temp_data = Mailbox[(tx_itr->second).first].access_with_flag(temp_flag);
 
     /*------------------------------------------------------
     If data has been updated, process
@@ -126,7 +126,7 @@ while( tx_itr != tx_test_cases.end() )
         if( memcmp( &((tx_itr->second).second), &temp_data, sizeof(data_union) ) == 0 )
             {
             return_value.uint32 = tx_itr->first;
-            Mailbox.update( return_value, static_cast<int>(mbx_index::TEST_RX_FROM_RPI_MSG ) );
+            Mailbox[mbx_index::TEST_RX_FROM_RPI_MSG] = return_value;
             }
         }
     /*------------------------------------------------------
@@ -143,7 +143,7 @@ while( rx_itr != rx_test_cases.end() )
     /*------------------------------------------------------
     Get test command
     ------------------------------------------------------*/
-    temp_data = Mailbox.access( mbx_index::TEST_TX_FROM_RPI_MSG, temp_flag );
+    temp_data = Mailbox[mbx_index::TEST_TX_FROM_RPI_MSG].access_with_flag(temp_flag);
 
     /*------------------------------------------------------
     Find command in rx_test_cases map
@@ -155,7 +155,7 @@ while( rx_itr != rx_test_cases.end() )
     ------------------------------------------------------*/
     if( pair != rx_test_cases.end() )
         {
-        Mailbox.update( (pair->second).second, static_cast<int>((pair->second).first) );
+        Mailbox[(pair->second).first] = (pair->second).second;
         }
 
     /*------------------------------------------------------


### PR DESCRIPTION
added support for overloading [] + had to also add a proxy class to handle `mailbox[idx] = y` vs `y = mailbox[idx]`