### PR TITLE
Remove direction enum type 

### DIFF
--- a/mailbox.tpp
+++ b/mailbox.tpp
@@ -508,7 +508,7 @@ for( i = 0; i < M; i++ )
 	/*--------------------------------------------------
 	Skip index if not a TX mailbox
 	--------------------------------------------------*/
-	if( currentMbx.dir != direction::TX )
+	if( currentMbx.source != current_location )
 		continue;
 
 	/*--------------------------------------------------
@@ -1049,11 +1049,11 @@ if( this->verify_index( global_mbx_indx) == mbx_index::MAILBOX_NONE )
 	}
 /*----------------------------------------------------------
 Verify tx/rx mode is accessed correctly. The user should only
-be able to set TX items, while the updater functions should
-only be able to set RX items
+be able to set TX items (source - us), while the updater 
+functions should only be able to set RX items (dest - us)
 ----------------------------------------------------------*/
-	if( ( user_mode && p_mailbox_ref[global_mbx_indx].dir == direction::RX   ) ||
-    ( !user_mode && p_mailbox_ref[global_mbx_indx].dir == direction::TX  ) )
+if( ( user_mode && p_mailbox_ref[global_mbx_indx].source != current_location   ) ||
+    ( !user_mode && p_mailbox_ref[global_mbx_indx].destination != current_location  ) )
 	{
 	this->log_error(mailbox_error_types::INVALID_API_CALL);
 	return false;
@@ -1082,7 +1082,7 @@ Update mailbox while protected
 	} /* release mutex */
 
 /*----------------------------------------------------------
-return true with data having been 
+return true with data having been updated
 ----------------------------------------------------------*/
 return true;
 

--- a/mailbox_types.hpp
+++ b/mailbox_types.hpp
@@ -68,15 +68,6 @@ enum struct update_rate : int /* Update rate (in rounds)            */
 
     NUM_UPDATE_RATES = 4      /* number of update rates             */
 };
-
-enum struct direction /* Direction of mailbox data                  */
-    {
-    TX,               /* transmit mailbox                           */
-    RX,               /* receive mailbox                            */
-
-    NUM_DIRECTINS     /* number of directions                       */
-    };
-
 const std::unordered_map< data_type, int> size_map /* size mapping of
                                                       data_types to 
                                                       byte size     */
@@ -91,7 +82,6 @@ typedef struct                     /* mailbox entry format          */
     data_type         type;        /* data type                     */
     update_rate       upt_rt;      /* update rate (in rounds)       */
     flag_type         flag;        /* data flag (status)            */
-    direction         dir;         /* data direction                */
     location          destination; /* data destination              */
     location          source;      /* data source                   */
     } mailbox_type;


### PR DESCRIPTION
src/dest serve the same purpose and they allow the config/map to be shared among all units instead of creating one per unit

Issue: CORE-55